### PR TITLE
Add Cloud Build for CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,5 @@ yarn-debug.log*
 # Ignore application configuration
 /config/application.yml
 
-# gCloud Cloud Build
-cloudbuild.yaml
-
 # Scripts
 /scripts/

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,10 +1,18 @@
 FROM ruby:2.7.1
+
+# Install and update dependencies
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
+
+# Set working directory
 RUN mkdir /farm_link
 WORKDIR /farm_link
+
+# Copy Gemfile and bundle install
 COPY Gemfile /farm_link/Gemfile
 COPY Gemfile.lock /farm_link/Gemfile.lock
 RUN bundle install
+
+# Copy code into container
 COPY . /farm_link
 
 # Expose external port

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -8,12 +8,12 @@ RUN mkdir /farm_link
 WORKDIR /farm_link
 
 # Copy Gemfile and bundle install
-COPY Gemfile /farm_link/Gemfile
-COPY Gemfile.lock /farm_link/Gemfile.lock
+COPY Gemfile ./Gemfile
+COPY Gemfile.lock ./Gemfile.lock
 RUN bundle install
 
 # Copy code into container
-COPY . /farm_link
+COPY . .
 
 # Expose external port
 EXPOSE 3000
@@ -21,7 +21,4 @@ EXPOSE 3000
 # Add a script to be executed every time the container starts.
 COPY entrypoint_development.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint_development.sh
-ENTRYPOINT ["entrypoint_development.sh"]
-
-# Start the main process.
-CMD ["rails", "server", "-b", "0.0.0.0"]
+ENTRYPOINT ["/usr/bin/entrypoint_development.sh"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,41 @@
+steps:
+
+# Decrypt Rails production key file
+- name: gcr.io/cloud-builders/gcloud
+  args: ["kms", "decrypt", "--ciphertext-file=./config/credentials/production.key.enc", 
+         "--plaintext-file=./config/credentials/production.key",
+         "--location=us-central1", "--keyring=farm-link-secrets", 
+         "--key=rails_key"]
+
+# Decrypt Rails master key file
+- name: gcr.io/cloud-builders/gcloud
+  args: ["kms", "decrypt", "--ciphertext-file=./config/master.key.enc", 
+         "--plaintext-file=./config/master.key",
+         "--location=us-central1", "--keyring=farm-link-secrets", 
+         "--key=rails_key_master"]
+
+# Decrypt Farm Link service account credentials
+- name: gcr.io/cloud-builders/gcloud
+  args: ["kms", "decrypt", "--ciphertext-file=./config/farm_link.key.enc", 
+         "--plaintext-file=./config/farm_link.key",
+         "--location=us-central1", "--keyring=farm-link-secrets", 
+         "--key=farm_link_key"]
+
+# Build image with tag 'latest' and pass decrypted Rails DB password as argument
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:latest', 
+         '--build-arg', 'DB_PASS', '--build-arg', 'MASTER_KEY', '.']
+  secretEnv: ['DB_PASS', 'MASTER_KEY']
+
+# Push new image to Google Container Registry       
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/farm-link-284523/farm_link:latest']
+
+secrets:
+  - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass
+    secretEnv:
+      DB_PASS: "CiQApGVp+nj+bh7h+JW+vJ4EYzvKUWb4Z1vRcYjSHaa/gRR5bMASNgCS4xNfiMc0ONzAwKVnQvZsltm7DVNDeKHhwVeE1BifR3R6HhWlUllmwBDaP6Z3avv66elGUg=="
+
+  - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/master_key_string
+    secretEnv:
+      MASTER_KEY: "CiQAupn5AHZWTHqkpZlPoYsICZhaXWc2gwsH2FHe/QbUEqQiqj0SSQC6p+jZEsHD7LpUe9K6ww2zgQt1BnPq8XyhZQ/GryKxIMie5YzLCK8Mt66nRPCWIEzqvo37jW/QPumeiDm5/0b7JBGYrf6v1iM="

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,27 +2,31 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  username: postgres
-  password: password
   host: db
   port: 5432
+  
+production:
+  <<: *default
+  database: farm_link_production
+  username: postgres
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host:  "/cloudsql/farm-link-284523:us-central1:farm-link-db"
+  
+staging:
+  <<: *default
+  database: farm_link_staging
+  username: <%= ENV["DB_USER"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host: 127.0.0.1
 
 development:
   <<: *default
   database: farm_link_development
-
-staging:
-  <<: *default
-  database: farm_link_staging
-  host: 127.0.0.1
+  username: <%= ENV["DB_USER"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
 
 test:
   <<: *default
   database: farm_link_test
-
-production:
-  <<: *default
-  username: postgres
+  username: <%= ENV["DB_USER"] %>
   password: <%= ENV["DATABASE_PASSWORD"] %>
-  database: farm_link_production
-  host:  "/cloudsql/farm-link-284523:us-central1:farm-link-db"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,13 @@ services:
     environment:
       POSTGRES_PASSWORD: password
   web:
-    build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    build:
+      context: .
+      dockerfile: Dockerfile.development
     volumes:
       - .:/farm_link
     ports:
       - "3000:3000"
-    image: iev0lv3/farm_link
+    image: farm_link
     depends_on:
       - db

--- a/entrypoint_development.sh
+++ b/entrypoint_development.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /farm_link/tmp/pids/server.pid
+rm -f ./tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"
+rails server -e development -b 0.0.0.0


### PR DESCRIPTION
# Description :: User Story

Added `.cloudbuild.yaml` to the root directory in order to allow for Continuous Deployment to Cloud Build whenever the `master` branch is updated. Cloud Build automatically finds `cloudbuild.yaml` and will run the build from that file.

Updated the `docker-compose.yml` file to use the `Dockerfile.development` file, and removed unnecessary `command` step in favor of using `entrypoint_development.sh` to initiate `rails server`.

Updated the `database.yml` file to use `ENV` variables when setting the database `username` and `password`.

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
