### PR TITLE
PR to `master` creates auto-deploy to staging

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,9 +45,6 @@ steps:
   - '--platform'
   - 'managed'
 
-images:
-  - 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA'
-
 secrets:
   - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass
     secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,13 +23,30 @@ steps:
 
 # Build image with tag 'latest' and pass decrypted Rails DB password as argument
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:latest', 
+  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA', 
          '--build-arg', 'DB_PASS', '--build-arg', 'MASTER_KEY', '.']
   secretEnv: ['DB_PASS', 'MASTER_KEY']
 
 # Push new image to Google Container Registry       
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/farm-link-284523/farm_link:latest']
+  args: ['push', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA']
+
+ # Deploy container image to Cloud Run
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args:
+  - 'run'
+  - 'deploy'
+  - 'farm-link-staging'
+  - '--image'
+  - 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA'
+  - '--region'
+  - 'us-central1'
+  - '--platform'
+  - 'managed'
+
+images:
+  - 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA'
 
 secrets:
   - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,6 +45,8 @@ steps:
   - '--platform'
   - 'managed'
 
+timeout: 900s
+
 secrets:
   - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass
     secretEnv:


### PR DESCRIPTION
# Description :: User Story

Continuous Deployment is now enabled when a pull request to the `master` branch is created. A pull request will trigger Cloud Build to create a container, publish it on Container Registry, and deploy it to the Cloud Run `farm-link-staging` service. 

This process will allow the application to be tested by humans in the live staging environment before being merged into the `master` branch. If multiple pull requests are made concurrently they will all be processed and deployed to `farm-link-staging`, at which point a team member can switch between all builds to test them one at a time. Each build will be tagged with it's associated pull request identifier from GitHub.

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
