### PR TITLE
CI/CD :: Now Active for `master` and `dev` branches

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,29 +14,22 @@ steps:
          "--location=us-central1", "--keyring=farm-link-secrets", 
          "--key=rails_key_master"]
 
-# Decrypt Farm Link service account credentials
-- name: gcr.io/cloud-builders/gcloud
-  args: ["kms", "decrypt", "--ciphertext-file=./config/farm_link.key.enc", 
-         "--plaintext-file=./config/farm_link.key",
-         "--location=us-central1", "--keyring=farm-link-secrets", 
-         "--key=farm_link_key"]
-
 # Build image with tag 'latest' and pass decrypted Rails DB password as argument
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA', 
+  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA', 
          '--build-arg', 'DB_PASS', '--build-arg', 'MASTER_KEY',
          '--file=./Dockerfile.slim', '.']
   secretEnv: ['DB_PASS', 'MASTER_KEY']
 
 # Push new image to Google Container Registry       
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA']
+  args: ['push', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA']
 
  # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
   args: ['run', 'deploy', 'farm-link-staging',
-  '--image', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA',
+  '--image', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA',
   '--region', 'us-central1', '--platform', 'managed']
 
 timeout: 900s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,12 +27,17 @@ steps:
 
  # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: gcloud
-  args: ['run', 'deploy', 'farm-link-staging',
+  entrypoint: [gcloud]
+  args: ['run', 'deploy', '${_SERVICE_NAME}',
+  '--build-arg', 'service_name=${_SERVICE_NAME}',
   '--image', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA',
-  '--region', 'us-central1', '--platform', 'managed']
+  '--region', 'us-central1',
+  '--platform', 'managed']
 
 timeout: 900s
+
+substitutions:
+  _SERVICE_NAME: farm-link-staging
 
 secrets:
   - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass


### PR DESCRIPTION
# Description :: User Story

The `dev` branch is now connected to the Cloud Run service `farm-link-staging`, and will be used as an intermediary before deploying to `master`. Any pushes into `dev` will automatically start Cloud Build to create a container, push it to Container Registry, and deploy it to Cloud Run as the `farm-link-staging` service.

The `master` branch is now connected to the Cloud Run service `farm-link-rails`. Any pushes into `master` will automatically start Cloud Build to create a container, push it to Container Registry, and deploy it to Cloud Run as the `farm-link-rails` service.

Both of the actions listed above are initiated using Cloud Build triggers, and they use the `cloudbuild.yaml` file. There is now a substitution variable connected to each trigger that contains a value of the service where the container should be deployed. This polymorphic relationship allows me to use a single `cloudbuild.yaml` file.

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
