### PR TITLE
Cloud Build :: Fix entrypoint gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
 
  # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: [gcloud]
+  entrypoint: gcloud
   args: ['run', 'deploy', '${_SERVICE_NAME}',
   '--build-arg', 'service_name=${_SERVICE_NAME}',
   '--image', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA',


### PR DESCRIPTION
# Description :: User Story

Changed `cloudbuild.yaml` entrypoint from `[gcloud]` to `gcloud`.

## Type of change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
