### PR TITLE
Dev

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,9 +27,8 @@ steps:
 
  # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: [gcloud]
+  entrypoint: gcloud
   args: ['run', 'deploy', '${_SERVICE_NAME}',
-  '--build-arg', 'service_name=${_SERVICE_NAME}',
   '--image', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA',
   '--region', 'us-central1',
   '--platform', 'managed']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,32 +14,30 @@ steps:
          "--location=us-central1", "--keyring=farm-link-secrets", 
          "--key=rails_key_master"]
 
-# Decrypt Farm Link service account credentials
-- name: gcr.io/cloud-builders/gcloud
-  args: ["kms", "decrypt", "--ciphertext-file=./config/farm_link.key.enc", 
-         "--plaintext-file=./config/farm_link.key",
-         "--location=us-central1", "--keyring=farm-link-secrets", 
-         "--key=farm_link_key"]
-
 # Build image with tag 'latest' and pass decrypted Rails DB password as argument
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA', 
+  args: ['build', '--tag', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA', 
          '--build-arg', 'DB_PASS', '--build-arg', 'MASTER_KEY',
          '--file=./Dockerfile.slim', '.']
   secretEnv: ['DB_PASS', 'MASTER_KEY']
 
 # Push new image to Google Container Registry       
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA']
+  args: ['push', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA']
 
  # Deploy container image to Cloud Run
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: gcloud
-  args: ['run', 'deploy', 'farm-link-staging',
-  '--image', 'gcr.io/farm-link-284523/farm_link:$COMMIT_SHA',
-  '--region', 'us-central1', '--platform', 'managed']
+  entrypoint: [gcloud]
+  args: ['run', 'deploy', '${_SERVICE_NAME}',
+  '--build-arg', 'service_name=${_SERVICE_NAME}',
+  '--image', 'gcr.io/farm-link-284523/farm_link:$SHORT_SHA',
+  '--region', 'us-central1',
+  '--platform', 'managed']
 
 timeout: 900s
+
+substitutions:
+  _SERVICE_NAME: farm-link-staging
 
 secrets:
   - kmsKeyName: projects/farm-link-284523/locations/us-central1/keyRings/farm-link-secrets/cryptoKeys/db_pass


### PR DESCRIPTION
# Description :: User Story

Added `substitutions` to `cloudbuild.yaml` for `_SERVICE_NAME`.
* This update allows Cloud Build to declare a substitution variable that defines which service it should deploy to
  * The `dev` branch deploys to `farm-link-staging`
  * The `master` branch deploys to the `farm-link-rails` service

The variable `$COMMIT_SHA` has been replaced with `$SHORT_SHA`
* This update makes it easier to identify containers

## Type of change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change

## Notes

## RSpec results

```
Paste RSpec results here
```

## Rubocop results

```
Paste Rubocop results here
```
